### PR TITLE
Prepare adjustment runtime for parachain migration

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -9,7 +9,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 mod weights;
 pub mod xcm_config;
 
-use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
+use cumulus_pallet_parachain_system::AnyRelayNumber;
 use smallvec::smallvec;
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
@@ -166,7 +166,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("subsocial-parachain"),
 	impl_name: create_runtime_str!("subsocial-parachain"),
 	authoring_version: 1,
-	spec_version: 20,
+	spec_version: 21,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 4,
@@ -263,12 +263,10 @@ parameter_types! {
 pub struct BaseFilter;
 impl Contains<RuntimeCall> for BaseFilter {
 	fn contains(c: &RuntimeCall) -> bool {
-		let is_force_transfer =
-			matches!(c, RuntimeCall::Balances(pallet_balances::Call::force_transfer { .. }));
-
 		match *c {
-			RuntimeCall::Balances(..) => is_force_transfer,
-			RuntimeCall::Vesting(pallet_vesting::Call::vested_transfer { .. }) => false,
+			RuntimeCall::Balances(..) => false,
+			RuntimeCall::Vesting(..) => false,
+			RuntimeCall::Energy(..) => false,
 			_ => true,
 		}
 	}
@@ -384,7 +382,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type XcmpMessageHandler = XcmpQueue;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
-	type CheckAssociatedRelayNumber = RelayNumberStrictlyIncreases;
+	type CheckAssociatedRelayNumber = AnyRelayNumber;
 }
 
 impl pallet_randomness_collective_flip::Config for Runtime {}


### PR DESCRIPTION
This PR contains the migration runtime that is deployed (on current Kusama Zeitgeist main-net) shortly before the migration to Polkadot. It is a temporary runtime that will be replaced by the proper production runtime after the migration. It ensures that all preconditions for a successful migration are met (i.e. no strictly increasing relay blocks) and that business logic is call-filtered (such as balance transfers). More information at https://hackmd.io/@lZVVinJVS6WI4IpRgmbsLA/Hkh6pSXCo